### PR TITLE
fixed player matching

### DIFF
--- a/UserSpecificFunctions/UserSpecificFunctions.csproj
+++ b/UserSpecificFunctions/UserSpecificFunctions.csproj
@@ -28,6 +28,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Data.Sqlite, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">


### PR DESCRIPTION
fixed a bug:
for example,if i entered command:
us color "233" 255,0,0
and another player named "233333" is existed
it won't work because it got two player in matched player list
as the original code,USF will print a tip at console and do nothing under the circumstances
so,the player named "233" will never be able to got permission,prefix,suffix or color
